### PR TITLE
Feature/comment tags

### DIFF
--- a/Editor/AseFileAnimationSettings.cs
+++ b/Editor/AseFileAnimationSettings.cs
@@ -10,10 +10,11 @@ namespace AsepriteImporter
         {
         }
 
-        public AseFileAnimationSettings(string name)
-        {
-            animationName = name;
-        }
+        // public AseFileAnimationSettings(string name, bool loop = true)
+        // {
+        //     animationName = name;
+        //     loopTime = loop;
+        // }
 
         [SerializeField] public string animationName;
         [SerializeField] public bool loopTime = true;

--- a/Editor/AseFileImporter.cs
+++ b/Editor/AseFileImporter.cs
@@ -166,10 +166,17 @@ namespace AsepriteImporter
             if (animationSettings != null)
                 RemoveUnusedAnimationSettings(animSettings, animations);
 
-            int index = 0;
+            // int index = 0;
 
-            foreach (var animation in animations)
+            for (int animationIndex = 0; animationIndex < animations.Length; animationIndex++)
             {
+                 FrameTag animation = animations[animationIndex];
+
+                 if(animation.TagName.Substring(0,2) == "//")
+                {
+                    continue;
+                }
+
                 AnimationClip animationClip = new AnimationClip();
                 animationClip.name = name + "_" + animation.TagName;
                 animationClip.frameRate = 25;
@@ -258,7 +265,7 @@ namespace AsepriteImporter
                 AnimationUtility.SetAnimationClipSettings(animationClip, settings);
                 ctx.AddObjectToAsset(animation.TagName, animationClip);
 
-                index++;
+                // index++;
             }
 
             animationSettings = animSettings.ToArray();

--- a/Editor/AseFileImporter.cs
+++ b/Editor/AseFileImporter.cs
@@ -25,7 +25,8 @@ namespace AsepriteImporter
 
     public static class Settings
     {
-        public static string COMMENT_TAGS = "//";
+        public static string COMMENT_TAGS = "//";       // Used to mark layers and animation tags as do not import
+        public static string LOOP_TAG_START = "-";        // Use at the beginning of an animation tag to mark as Loop Once
     }
 
 
@@ -184,11 +185,13 @@ namespace AsepriteImporter
                 }
 
                 AnimationClip animationClip = new AnimationClip();
-                animationClip.name = name + "_" + animation.TagName;
-                animationClip.frameRate = 25;
-
+        
                 AseFileAnimationSettings importSettings = GetAnimationSettingFor(animSettings, animation);
                 importSettings.about = GetAnimationAbout(animation);
+                
+
+                animationClip.name = name + "_" + animation.TagName;
+                animationClip.frameRate = 25;
 
 
                 EditorCurveBinding editorBinding = new EditorCurveBinding();
@@ -312,7 +315,19 @@ namespace AsepriteImporter
                     return animationSettings[i];
             }
 
-            animationSettings.Add(new AseFileAnimationSettings(animation.TagName));
+            AseFileAnimationSettings aseFileAnimationSetting = new AseFileAnimationSettings();
+           
+            Debug.Log("Before: " + animation.TagName);
+            Debug.Log("checking " + animation.TagName.Substring(0, 1));
+            if(animation.TagName.Substring(0,1) ==Settings.LOOP_TAG_START)
+            {
+                animation.TagName = animation.TagName.Substring(1,animation.TagName.Length-1);
+                aseFileAnimationSetting.loopTime = false;  
+            }
+
+            Debug.Log("After: " + animation.TagName);
+            aseFileAnimationSetting.animationName = animation.TagName;
+            animationSettings.Add(aseFileAnimationSetting);
             return animationSettings[animationSettings.Count - 1];
         }
 

--- a/Editor/AseFileImporter.cs
+++ b/Editor/AseFileImporter.cs
@@ -23,6 +23,12 @@ namespace AsepriteImporter
         UIImage
     }
 
+    public static class Settings
+    {
+        public static string COMMENT_TAGS = "//";
+    }
+
+
     [ScriptedImporter(1, new []{ "ase", "aseprite" })]
     public class AseFileImporter : ScriptedImporter
     {
@@ -172,7 +178,7 @@ namespace AsepriteImporter
             {
                  FrameTag animation = animations[animationIndex];
 
-                 if(animation.TagName.Substring(0,2) == "//")
+                 if(animation.TagName.Substring(0,2) == Settings.COMMENT_TAGS)
                 {
                     continue;
                 }

--- a/Editor/Aseprite/AseFile.cs
+++ b/Editor/Aseprite/AseFile.cs
@@ -85,6 +85,11 @@ namespace Aseprite
 
             for (int i = 0; i < layers.Count; i++)
             {
+                if(layers[i].LayerName.Substring(0,2) == AsepriteImporter.Settings.COMMENT_TAGS)
+                {
+                    continue;
+                }
+
                 List<Texture2D> layerFrames = GetLayerTexture(i, layers[i]);
 
                 if (layerFrames.Count > 0)
@@ -129,6 +134,8 @@ namespace Aseprite
 
                 for (int i = 0; i < cels.Count; i++)
                 {
+                    bool commentedOut = layers[i].LayerName.Substring(0,2) == AsepriteImporter.Settings.COMMENT_TAGS;
+
                     if (cels[i].LayerIndex != layerIndex)
                         continue;
 
@@ -141,13 +148,13 @@ namespace Aseprite
                     while (parent != null)
                     {
                         visibility &= parent.Visible;
-                        if (visibility == false)
+                        if (visibility == false || commentedOut)
                             break;
 
                         parent = GetParentLayer(parent);
                     }
 
-                    if (visibility == false || layer.LayerType == LayerType.Group)
+                    if (visibility == false || layer.LayerType == LayerType.Group || commentedOut)
                         continue;
 
                     textures.Add(GetTextureFromCel(cels[i]));

--- a/Editor/Aseprite/AseFile.cs
+++ b/Editor/Aseprite/AseFile.cs
@@ -179,6 +179,8 @@ namespace Aseprite
             for (int i = 0; i < cels.Count; i++)
             {
                 LayerChunk layer = layers[cels[i].LayerIndex];
+                if(layers[i].LayerName.Substring(0,2) == AsepriteImporter.Settings.COMMENT_TAGS)
+                    continue;
 
                 LayerBlendMode blendMode = layer.BlendMode;
                 float opacity = Mathf.Min(layer.Opacity / 255f, cels[i].Opacity / 255f);

--- a/Editor/Aseprite/Chunks/FrameTagsChunk.cs
+++ b/Editor/Aseprite/Chunks/FrameTagsChunk.cs
@@ -21,7 +21,7 @@ namespace Aseprite.Chunks
         private byte[] ForFuture { get; set; } // 8 Bytes
         public Color TagColor { get; set; } // 3 Bytes
         // 1 Extra Byte
-        public string TagName { get; private set; }
+        public string TagName { get; set; }
 
         public FrameTag(BinaryReader reader)
         {


### PR DESCRIPTION
Added feature to use comment tags to prevent either the tagged animation or layer to render upon import. 

"//" placed in front of the animation tag or layer name are ignored from renders upon import.
"-" placed in from of the animation tag denotes that the animation will only loop once.